### PR TITLE
fix: remove `lowercase` in className

### DIFF
--- a/src/app/(main)/form/[id]/submissions-table.tsx
+++ b/src/app/(main)/form/[id]/submissions-table.tsx
@@ -95,16 +95,12 @@ export function SubmissionsTable({
               className="px-0 py-0 capitalize hover:bg-transparent"
             >
               {submission}
-              <CaretSortIcon className="ml-2 h-4 w-4" />
+              {/* <CaretSortIcon className="ml-2 h-4 w-4" /> */}
             </Button>
           );
         },
         cell: ({ row }: any) => {
-          return (
-            <div className="lowercase">
-              {row.original[`data.${submission}`]}
-            </div>
-          );
+          return <div>{row.original[`data.${submission}`]}</div>;
         },
       };
     }),


### PR DESCRIPTION
this is to prevent a submission from being presented differently than it was typed during submission.