### PR TITLE
fix: add has trap to lazy auth proxy so auth routes resolve handler

### DIFF
--- a/packages/auth/index.ts
+++ b/packages/auth/index.ts
@@ -81,6 +81,9 @@ export const auth = new Proxy({} as Auth, {
     const value = Reflect.get(authClient, property);
     return typeof value === 'function' ? value.bind(authClient) : value;
   },
+  has(_target, property) {
+    return Reflect.has(getAuth(), property);
+  },
 });
 
 export type Session = typeof auth.$Infer.Session;

--- a/packages/auth/index.ts
+++ b/packages/auth/index.ts
@@ -78,8 +78,10 @@ const getAuth = () => {
 export const auth = new Proxy({} as Auth, {
   get(_target, property) {
     const authClient = getAuth();
-    const value = Reflect.get(authClient, property);
-    return typeof value === 'function' ? value.bind(authClient) : value;
+    const value: unknown = Reflect.get(authClient, property);
+    return typeof value === 'function'
+      ? (value as (...args: unknown[]) => unknown).bind(authClient)
+      : value;
   },
   has(_target, property) {
     return Reflect.has(getAuth(), property);

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -30,8 +30,10 @@ const getQueryClient = () => {
 export const queryClient = new Proxy({} as Client, {
   get(_target, property) {
     const client = getQueryClient();
-    const value = Reflect.get(client, property);
-    return typeof value === 'function' ? value.bind(client) : value;
+    const value: unknown = Reflect.get(client, property);
+    return typeof value === 'function'
+      ? (value as (...args: unknown[]) => unknown).bind(client)
+      : value;
   },
   set(_target, property, value) {
     return Reflect.set(getQueryClient(), property, value);
@@ -55,8 +57,10 @@ const getDb = () => {
 export const db = new Proxy({} as Database, {
   get(_target, property) {
     const database = getDb();
-    const value = Reflect.get(database, property);
-    return typeof value === 'function' ? value.bind(database) : value;
+    const value: unknown = Reflect.get(database, property);
+    return typeof value === 'function'
+      ? (value as (...args: unknown[]) => unknown).bind(database)
+      : value;
   },
   set(_target, property, value) {
     return Reflect.set(getDb(), property, value);


### PR DESCRIPTION
## Problem

In production (Cloudflare Workers), every `POST /api/auth/*` returned `500` with `TypeError: e8 is not a function`, breaking sign-in (observed on `/api/auth/sign-in/social`).

## Root cause

`packages/auth/index.ts` exposes `auth` as a lazy `new Proxy({}, { get })` to defer `createAuth()` past build-time env validation. It trapped only `get` — **not `has`**.

better-auth's `toNextJsHandler` runs this per request:

```js
return "handler" in auth ? auth.handler(request) : auth(request);
```

With no `has` trap, `"handler" in auth` forwards to the empty proxy target `{}` → `false`, so better-auth falls through to `auth(request)`. The proxy isn't callable → `TypeError: auth is not a function` (minified to `e8`).

This breaks all `/api/auth/*` HTTP routes (social **and** email). Server-side `auth.api.getSession(...)` was unaffected because it goes through the `get` trap — which is why page session checks kept working and only the sign-in POSTs 500'd.

## Fix

Add a `has` trap that forwards to the real instance:

```js
has(_target, property) {
  return Reflect.has(getAuth(), property);
},
```

Build-time safe: `toNextJsHandler` only evaluates `"handler" in auth` inside its per-request closure, never at module load, so the env-validation decoupling is preserved.

## Verification

Reproduced against the actual published `better-auth@1.4.10` + `toNextJsHandler`, posting to `/api/auth/sign-in/social`:

- **Before** (get-only proxy): `TypeError: auth is not a function` — matches prod `e8`.
- **After** (with `has` trap): `200` with `{"url":"https://github.com/login/oauth/authorize?..."}`.

## Note

Deploying this requires a Worker rebuild + redeploy to ship the new bundle. No env/secret/DNS changes needed.