### PR TITLE
feat: move email to Cloudflare Email Service

### DIFF
--- a/apps/web/.env.development.example
+++ b/apps/web/.env.development.example
@@ -19,7 +19,6 @@ SMTP_PORT=2500
 # Inbucket does not require auth; leave these empty for local testing.
 SMTP_USER=
 SMTP_PASS=
-RESEND_API_KEY=
 
 # Formbase
 ALLOW_SIGNIN_SIGNUP=true

--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -12,9 +12,12 @@ AUTH_GITHUB_SECRET=
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
 
-# Email (Resend)
-SMTP_TRANSPORT=resend
-RESEND_API_KEY=
+# Email (Cloudflare Email Service)
+SMTP_TRANSPORT=cloudflare
+CLOUDFLARE_ACCOUNT_ID=8e642ff58d22bbbe4eda926dda88649e
+CLOUDFLARE_API_TOKEN=
+# Sender on your verified Cloudflare domain, e.g. Formbase <noreply@mail.yourdomain>
+EMAIL_FROM=
 
 # Formbase
 ALLOW_SIGNIN_SIGNUP=true

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -40,6 +40,7 @@ const createSmtpTransport = async (): Promise<MailTransporter> => {
         }
       : {}),
   };
+  // Dynamic import keeps Node-only nodemailer out of Cloudflare email transport bundles.
   const { createTransport } = await import('nodemailer');
 
   return createTransport(smtpConfig as TransportOptions);
@@ -51,6 +52,7 @@ const getTransporter = async () => {
   if (cachedTransporter) return cachedTransporter;
 
   if (env.NODE_ENV === 'test') {
+    // Dynamic import keeps Node-only nodemailer out of Cloudflare email transport bundles.
     const { createTransport } = await import('nodemailer');
     cachedTransporter = createTransport({
       name: 'noop',
@@ -78,7 +80,7 @@ const getTransporter = async () => {
 
   if (!hasSmtpConfig) {
     throw new Error(
-      'Email transport not configured. Set SMTP_TRANSPORT to resend or smtp.',
+      'Email transport not configured. Set SMTP_TRANSPORT to cloudflare or smtp.',
     );
   }
 
@@ -86,42 +88,50 @@ const getTransporter = async () => {
   return cachedTransporter;
 };
 
-const sendResendMail = async ({
+const sendCloudflareMail = async ({
   to,
   subject,
   body,
 }: MessageInfo): Promise<unknown> => {
-  if (!env.RESEND_API_KEY) {
-    throw new Error('Missing RESEND_API_KEY');
+  const apiToken = env.CLOUDFLARE_API_TOKEN;
+  const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+
+  if (!apiToken || !accountId) {
+    throw new Error('Missing CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID');
   }
 
-  const response = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${env.RESEND_API_KEY}`,
-      'Content-Type': 'application/json',
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/email/sending/send`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: env.EMAIL_FROM ?? from,
+        to,
+        subject,
+        html: body,
+      }),
     },
-    body: JSON.stringify({
-      from,
-      to,
-      subject,
-      html: body,
-    }),
-  });
+  );
+  const result = (await response.json().catch(() => null)) as {
+    success?: boolean;
+    errors?: Array<{ message?: unknown }>;
+  } | null;
 
-  if (!response.ok) {
-    const errorBody = (await response.json().catch(() => null)) as {
-      message?: unknown;
-    } | null;
+  if (!response.ok || result?.success !== true) {
+    const errorMessage = result?.errors?.[0]?.message;
     const message =
-      typeof errorBody?.message === 'string'
-        ? errorBody.message
-        : `Resend email request failed with status ${response.status}`;
+      typeof errorMessage === 'string'
+        ? errorMessage
+        : `Cloudflare email request failed with status ${response.status}`;
 
     throw new Error(message);
   }
 
-  return response.json();
+  return result;
 };
 
 export const sendMail = async ({
@@ -129,8 +139,8 @@ export const sendMail = async ({
   subject,
   body,
 }: MessageInfo): Promise<unknown> => {
-  if (env.SMTP_TRANSPORT === 'resend') {
-    return sendResendMail({ to, subject, body });
+  if (env.SMTP_TRANSPORT === 'cloudflare') {
+    return sendCloudflareMail({ to, subject, body });
   }
 
   const transporter = await getTransporter();

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -58,8 +58,10 @@ export const env = createEnv({
     STORAGE_BUCKET: z.string().trim().min(1).optional(),
     STORAGE_REGION: z.string().trim().min(1).optional(),
 
-    RESEND_API_KEY: z.string().trim().optional(),
-    SMTP_TRANSPORT: z.enum(['smtp', 'resend']).optional(),
+    SMTP_TRANSPORT: z.enum(['smtp', 'cloudflare']).optional(),
+    CLOUDFLARE_API_TOKEN: z.string().trim().optional(),
+    CLOUDFLARE_ACCOUNT_ID: z.string().trim().optional(),
+    EMAIL_FROM: z.string().trim().min(1).optional(),
 
     CRON_SECRET: z.string().trim().min(1).optional(),
     VERCEL_URL: z.string().optional(),

--- a/tests/api/email.test.ts
+++ b/tests/api/email.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sendMail } from '../../packages/email/index';
+
+const accountId = '8e642ff58d22bbbe4eda926dda88649e';
+const apiToken = 'test-cloudflare-token';
+const emailFrom = 'Formbase <noreply@mail.example.com>';
+
+beforeEach(() => {
+  vi.stubEnv('SMTP_TRANSPORT', 'cloudflare');
+  vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', accountId);
+  vi.stubEnv('CLOUDFLARE_API_TOKEN', apiToken);
+  vi.stubEnv('EMAIL_FROM', emailFrom);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('Cloudflare email transport', () => {
+  it('sends email through the Cloudflare REST API', async () => {
+    const apiResponse = {
+      success: true,
+      errors: [],
+      result: {
+        delivered: ['user@example.com'],
+        permanent_bounces: [],
+        queued: [],
+      },
+    };
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
+      Response.json(apiResponse, { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendMail({
+        to: 'user@example.com',
+        subject: 'Welcome',
+        body: '<p>Hello</p>',
+      }),
+    ).resolves.toEqual(apiResponse);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error('Expected Cloudflare fetch call');
+
+    const [url, init] = call;
+    expect(url).toBe(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/email/sending/send`,
+    );
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      from: emailFrom,
+      to: 'user@example.com',
+      subject: 'Welcome',
+      html: '<p>Hello</p>',
+    });
+  });
+
+  it('throws the Cloudflare API error message', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
+      Response.json(
+        {
+          success: false,
+          errors: [
+            {
+              code: 10001,
+              message: 'email.sending.error.invalid_request_schema',
+            },
+          ],
+          result: null,
+        },
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendMail({
+        to: 'user@example.com',
+        subject: 'Welcome',
+        body: '<p>Hello</p>',
+      }),
+    ).rejects.toThrow('email.sending.error.invalid_request_schema');
+  });
+
+  it('throws the Cloudflare API error message for non-ok responses', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
+      Response.json(
+        {
+          success: false,
+          errors: [
+            {
+              code: 10001,
+              message: 'email.sending.error.invalid_request_schema',
+            },
+          ],
+          result: null,
+        },
+        { status: 400 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendMail({
+        to: 'user@example.com',
+        subject: 'Welcome',
+        body: '<p>Hello</p>',
+      }),
+    ).rejects.toThrow('email.sending.error.invalid_request_schema');
+  });
+});


### PR DESCRIPTION
## Summary
- replace Resend email transport with Cloudflare Email Service REST API transport
- add Cloudflare email env vars and update env examples
- add tests for Cloudflare email send success and error handling

## Verification
- `cd tests && bunx vitest run`
- `cd packages/email && bun run typecheck`
- `cd packages/env && bun run typecheck`
- `bunx prettier --ignore-unknown --check packages/env/index.ts packages/email/index.ts apps/web/.env.production.example apps/web/.env.development.example tests/api/email.test.ts`