### PR TITLE
fix: prevent submission endpoint hang on Cloudflare Workers

### DIFF
--- a/apps/web/src/app/api/s/[id]/route.ts
+++ b/apps/web/src/app/api/s/[id]/route.ts
@@ -1,4 +1,4 @@
-import { userAgent } from 'next/server';
+import { after, userAgent } from 'next/server';
 
 import { type RouterOutputs } from '@formbase/api';
 
@@ -142,7 +142,11 @@ export async function POST(
     });
 
     if (!spamResult.isSpam) {
-      void handleEmailNotifications(form, cleanedFormData);
+      after(() =>
+        handleEmailNotifications(form, cleanedFormData).catch((error) => {
+          console.error('Failed to send submission notification email', error);
+        }),
+      );
     }
     const { browser } = userAgent(request);
 

--- a/packages/api/routers/formData.ts
+++ b/packages/api/routers/formData.ts
@@ -120,26 +120,25 @@ export const formDataRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      return await ctx.db.transaction(async (tx) => {
-        const formdata = await tx.insert(formDatas).values({
+      const [formdata] = await ctx.db.batch([
+        ctx.db.insert(formDatas).values({
           data: serializeJson(input.data),
           formId: input.formId,
           id: generateId(15),
           createdAt: new Date(),
           isSpam: input.isSpam,
           spamReason: input.spamReason ?? null,
-        });
-
-        await tx
+        }),
+        ctx.db
           .update(forms)
           .set({
             updatedAt: new Date(),
             keys: serializeJson(input.keys),
           })
-          .where(eq(forms.id, input.formId));
+          .where(eq(forms.id, input.formId)),
+      ]);
 
-        return formdata;
-      });
+      return formdata;
     }),
 
   markAsSpam: protectedProcedure


### PR DESCRIPTION
## Symptom

Production logs for `POST https://formbase.dev/s/<id>` (JSON body, fired repeatedly under load):

- `outcome: "exception"`, HTTP 500, `cpuTimeMs: 6` — waiting on I/O, not CPU-bound.
- `"The Workers runtime canceled this request because it detected that your Worker's code had hung and would never generate a response."`

## Root cause

**Primary — interactive DB transaction holds the libSQL write lock across round-trips.** `formData.setFormData` wrapped its two writes in `ctx.db.transaction(async (tx) => …)`. Against networked Turso/libSQL that is `BEGIN → INSERT → UPDATE → COMMIT` = **4 sequential network round-trips holding the single write lock for their whole duration**. Under concurrent submissions they serialize on that lock; stacked round-trip latency blows the Worker execution budget, so workerd kills the request as hung. (Existing tests miss it because they run against local `file::memory:` libSQL — no network latency, no lock contention.)

**Secondary — fire-and-forget email is invalid on Workers.** The handler sent the notification email via `void handleEmailNotifications(...)`. I/O started by a floating promise that outlives the response is invalid on Workers, so notification emails silently failed (and could surface as the request `exception`). Email defaults on for every form, so this fired on each non-spam submission.

## Fix

- **`packages/api/routers/formData.ts`** — replace the interactive transaction with a single atomic `ctx.db.batch([insert, update])`. Drizzle libSQL `batch` runs both statements in **one round-trip inside an implicit backend transaction** (all-or-nothing rollback — identical atomicity), holding the write lock only briefly server-side. Return value (insert result) preserved via `const [formdata] = …`.
- **`apps/web/src/app/api/s/[id]/route.ts`** — defer the email with Next's `after()` instead of a floating promise. `after()` runs it in a valid post-response context (OpenNext maps it to `waitUntil`); a `.catch()` keeps a failed email from escalating to a request exception.

## Out of scope (considered, deliberately not done)

- Converting the module-level libSQL singleton to the `@libsql/client/web` (HTTP) build / per-request client — larger, riskier, breaks the `file:` test + migration paths, and unnecessary once `batch` removes the lock-hold-across-round-trips. Noted as possible future hardening.
- Speculative input validation / body-size caps — not the cause.

## Verification

- Targeted suites — **30/30 pass**: `tests/routes/submission.test.ts` (5, including the FK-failure case `rejects.toThrow()`, which proves `batch` preserves atomic rollback; plus keys-update, `updatedAt`-update, defined-return), `tests/routes/json-parsing.test.ts` (22), `tests/api/email.test.ts` (3).
- `packages/api` typecheck: clean. `apps/web` typecheck: both edited files error-free and the `after` import resolves (the 13 build errors are pre-existing in unrelated `packages/ui` primitives — identical count with and without this change).
- Prettier: both edited files conform.

**Honest limit:** the production hang can't be reproduced locally (needs networked Turso + workerd + secrets). Root cause is established by code analysis (only interactive transaction, in the exact failing path), libSQL/Drizzle semantics (interactive txn = multi-round-trip lock hold; `batch` = single atomic round-trip), and the local-vs-networked test asymmetry. The `batch` fix targets that root cause directly and is regression-checked by the existing suite.