### PR TITLE
feat: add webhooks via Cloudflare Queues and Cron Triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ web_modules/
 .next
 .open-next
 next-env.d.ts
+cloudflare-env.d.ts
 out
 
 # Nuxt.js build / generate output

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,10 +1,22 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare';
 
 initOpenNextCloudflareForDev();
 
+const monorepoRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: monorepoRoot,
+  turbopack: {
+    root: monorepoRoot,
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/src/app/(main)/form/[id]/form-settings.tsx
+++ b/apps/web/src/app/(main)/form/[id]/form-settings.tsx
@@ -3,12 +3,14 @@
 import { useRouter } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { formatDistanceToNow } from 'date-fns';
 import {
   BellRing,
   ExternalLink,
   FolderPen,
   FolderX,
   Shield,
+  Webhook,
 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -16,6 +18,7 @@ import { z } from 'zod';
 
 import { type RouterOutputs } from '@formbase/api';
 import { type User } from '@formbase/auth';
+import { Badge } from '@formbase/ui/primitives/badge';
 import {
   Form,
   FormControl,
@@ -27,7 +30,9 @@ import {
 import { Input } from '@formbase/ui/primitives/input';
 import { Label } from '@formbase/ui/primitives/label';
 import { Switch } from '@formbase/ui/primitives/switch';
+import { isValidWebhookUrl } from '@formbase/utils/webhook';
 
+import { CopyButton } from '~/components/copy-button';
 import { LoadingButton } from '~/components/loading-button';
 import { api } from '~/lib/trpc/react';
 
@@ -56,6 +61,18 @@ const defaultSubmissionEmailSchema = z.object({
 
 const honeypotFieldSchema = z.object({
   honeypotField: z.string().min(1).optional(),
+});
+
+const webhookSettingsSchema = z.object({
+  enableWebhook: z.boolean().default(false).optional(),
+  webhookUrl: z
+    .string()
+    .url()
+    .refine(isValidWebhookUrl, {
+      message: 'URL must use HTTPS (localhost allowed for development)',
+    })
+    .optional()
+    .or(z.literal('')),
 });
 
 type FormNameSchema = z.infer<typeof formNameSchema>;
@@ -111,6 +128,13 @@ export function FormSettings({ form, user }: FormSettingsProps) {
       <HoneypotFieldSetting
         formId={form.id}
         honeypotField={form.honeypotField}
+      />
+
+      <WebhookSettings
+        formId={form.id}
+        enableWebhook={form.enableWebhook}
+        webhookUrl={form.webhookUrl ?? ''}
+        webhookSecret={form.webhookSecret ?? null}
       />
 
       <div className="flex flex-row items-center justify-between rounded-lg border p-4">
@@ -595,5 +619,235 @@ const HoneypotFieldSetting = ({
         />
       </form>
     </Form>
+  );
+};
+
+type WebhookSettingsSchema = z.infer<typeof webhookSettingsSchema>;
+
+const WebhookSettings = ({
+  formId,
+  enableWebhook,
+  webhookUrl,
+  webhookSecret,
+}: {
+  formId: string;
+  enableWebhook: boolean;
+  webhookUrl: string;
+  webhookSecret: string | null;
+}) => {
+  const router = useRouter();
+
+  const webhookForm = useForm<WebhookSettingsSchema>({
+    resolver: zodResolver(webhookSettingsSchema),
+    defaultValues: {
+      enableWebhook,
+      webhookUrl,
+    },
+  });
+
+  const watchEnableWebhook = webhookForm.watch('enableWebhook');
+
+  const { mutateAsync: updateWebhookSettings, isPending: isUpdating } =
+    api.form.update.useMutation();
+
+  const { mutateAsync: testWebhook, isPending: isTesting } =
+    api.form.testWebhook.useMutation();
+
+  const { data: deliveries } = api.form.listDeliveries.useQuery(
+    { formId },
+    { enabled: watchEnableWebhook ?? false },
+  );
+
+  async function handleEnableWebhookChange(isChecked: boolean) {
+    webhookForm.setValue('enableWebhook', isChecked);
+
+    try {
+      await updateWebhookSettings({
+        id: formId,
+        enableWebhook: isChecked,
+      });
+
+      toast(
+        isChecked ? 'Webhook has been enabled' : 'Webhook has been disabled',
+        { icon: <Webhook className="h-4 w-4" /> },
+      );
+
+      router.refresh();
+    } catch {
+      toast('Failed to update webhook settings', {
+        description: 'Please try again later',
+        icon: <FolderX className="h-4 w-4" />,
+      });
+    }
+  }
+
+  async function handleWebhookUrlSubmit(data: WebhookSettingsSchema) {
+    try {
+      await updateWebhookSettings({
+        id: formId,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        webhookUrl: data.webhookUrl || null,
+      });
+
+      toast('Webhook URL has been updated', {
+        icon: <Webhook className="h-4 w-4" />,
+      });
+
+      router.refresh();
+    } catch {
+      toast('Failed to update webhook URL', {
+        description: 'URL must use HTTPS (localhost allowed for development)',
+        icon: <FolderX className="h-4 w-4" />,
+      });
+    }
+  }
+
+  async function handleTestWebhook() {
+    try {
+      await testWebhook({ formId });
+      toast('Test webhook has been queued', {
+        description: 'Check your webhook endpoint for the delivery',
+        icon: <Webhook className="h-4 w-4" />,
+      });
+    } catch {
+      toast('Failed to send test webhook', {
+        description: 'Make sure webhook is enabled and URL is configured',
+        icon: <FolderX className="h-4 w-4" />,
+      });
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <Form {...webhookForm}>
+        <FormField
+          control={webhookForm.control}
+          name="enableWebhook"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between">
+              <div className="space-y-0.5">
+                <FormLabel className="text-base">Enable Webhook</FormLabel>
+                <FormDescription>
+                  Send an HTTP POST request on every form submission
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value ?? false}
+                  onCheckedChange={handleEnableWebhookChange}
+                  disabled={isUpdating}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </Form>
+
+      {watchEnableWebhook && (
+        <>
+          <Form {...webhookForm}>
+            <form onSubmit={webhookForm.handleSubmit(handleWebhookUrlSubmit)}>
+              <FormField
+                control={webhookForm.control}
+                name="webhookUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Webhook URL</FormLabel>
+                    <FormControl>
+                      <div className="flex gap-2">
+                        <Input
+                          className="flex-1"
+                          {...field}
+                          placeholder="https://example.com/webhook"
+                          type="url"
+                        />
+                        <LoadingButton
+                          loading={isUpdating}
+                          type="submit"
+                          variant="default"
+                        >
+                          Save
+                        </LoadingButton>
+                        <LoadingButton
+                          loading={isTesting}
+                          type="button"
+                          variant="outline"
+                          onClick={handleTestWebhook}
+                          disabled={!webhookUrl}
+                        >
+                          Test
+                        </LoadingButton>
+                      </div>
+                    </FormControl>
+                    <FormDescription>
+                      Must use HTTPS (localhost allowed for development)
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+            </form>
+          </Form>
+
+          {webhookSecret && (
+            <div className="space-y-0.5">
+              <Label>Signing secret</Label>
+              <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2">
+                <code className="flex-1 truncate font-mono text-sm">
+                  {webhookSecret}
+                </code>
+                <CopyButton text={webhookSecret} />
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Used to verify the X-Formbase-Signature header on each request
+              </p>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label>Recent deliveries</Label>
+            {deliveries && deliveries.length > 0 ? (
+              <div className="divide-y rounded-md border">
+                {deliveries.map((delivery) => (
+                  <div
+                    key={delivery.id}
+                    className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
+                  >
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        variant={
+                          delivery.status === 'success'
+                            ? 'secondary'
+                            : delivery.status === 'failed'
+                              ? 'destructive'
+                              : 'outline'
+                        }
+                      >
+                        {delivery.status}
+                      </Badge>
+                      {delivery.statusCode !== null && (
+                        <span className="text-muted-foreground">
+                          HTTP {delivery.statusCode}
+                        </span>
+                      )}
+                      <span className="text-muted-foreground">
+                        {delivery.attempts} attempt
+                        {delivery.attempts === 1 ? '' : 's'}
+                      </span>
+                    </div>
+                    <span className="text-muted-foreground">
+                      {formatDistanceToNow(delivery.createdAt, {
+                        addSuffix: true,
+                      })}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No deliveries yet</p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
   );
 };

--- a/apps/web/src/app/(main)/form/[id]/form-settings.tsx
+++ b/apps/web/src/app/(main)/form/[id]/form-settings.tsx
@@ -794,7 +794,7 @@ const WebhookSettings = ({
           </Form>
 
           {webhookSecret && (
-            <div className="space-y-0.5">
+            <div className="space-y-2">
               <Label>Signing secret</Label>
               <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2">
                 <code className="flex-1 truncate font-mono text-sm">

--- a/apps/web/src/app/(main)/form/[id]/form-settings.tsx
+++ b/apps/web/src/app/(main)/form/[id]/form-settings.tsx
@@ -646,6 +646,7 @@ const WebhookSettings = ({
   });
 
   const watchEnableWebhook = webhookForm.watch('enableWebhook');
+  const watchWebhookUrl = webhookForm.watch('webhookUrl');
 
   const { mutateAsync: updateWebhookSettings, isPending: isUpdating } =
     api.form.update.useMutation();
@@ -693,6 +694,10 @@ const WebhookSettings = ({
         icon: <Webhook className="h-4 w-4" />,
       });
 
+      webhookForm.reset({
+        enableWebhook: webhookForm.getValues('enableWebhook'),
+        webhookUrl: data.webhookUrl ?? '',
+      });
       router.refresh();
     } catch {
       toast('Failed to update webhook URL', {
@@ -773,7 +778,7 @@ const WebhookSettings = ({
                           type="button"
                           variant="outline"
                           onClick={handleTestWebhook}
-                          disabled={!webhookUrl}
+                          disabled={!watchWebhookUrl || webhookForm.formState.isDirty}
                         >
                           Test
                         </LoadingButton>

--- a/apps/web/src/app/api/s/[id]/route.ts
+++ b/apps/web/src/app/api/s/[id]/route.ts
@@ -1,3 +1,4 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { after, userAgent } from 'next/server';
 
 import { type RouterOutputs } from '@formbase/api';
@@ -7,6 +8,7 @@ import { renderNewSubmissionEmail } from '~/lib/email/templates/new-submission';
 import { checkForSpam, stripHoneypotField } from '~/lib/spam-detection';
 import { api } from '~/lib/trpc/server';
 import { assignFileOrImage, uploadFileFromBlob } from '~/lib/upload-file';
+import { enqueueWebhook } from '~/lib/webhooks/producer';
 
 type FormDataResult =
   | {
@@ -133,7 +135,7 @@ export async function POST(
     const formKeys = form.keys;
     const updatedKeys = [...new Set([...formKeys, ...formDataKeys])];
 
-    await api.formData.setFormData({
+    const { id: formDataId } = await api.formData.setFormData({
       data: cleanedFormData,
       formId,
       keys: updatedKeys,
@@ -145,6 +147,21 @@ export async function POST(
       after(() =>
         handleEmailNotifications(form, cleanedFormData).catch((error) => {
           console.error('Failed to send submission notification email', error);
+        }),
+      );
+    }
+
+    if (!spamResult.isSpam && form.enableWebhook && form.webhookUrl) {
+      const { env } = getCloudflareContext();
+      const queue = env.WEBHOOK_QUEUE;
+      const webhookUrl = form.webhookUrl;
+      after(() =>
+        enqueueWebhook(queue, {
+          formId,
+          formDataId,
+          webhookUrl,
+        }).catch((error: unknown) => {
+          console.error('Failed to enqueue webhook', error);
         }),
       );
     }

--- a/apps/web/src/app/api/s/[id]/route.ts
+++ b/apps/web/src/app/api/s/[id]/route.ts
@@ -1,4 +1,3 @@
-import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { after, userAgent } from 'next/server';
 
 import { type RouterOutputs } from '@formbase/api';
@@ -145,21 +144,22 @@ export async function POST(
 
     if (!spamResult.isSpam) {
       after(() =>
-        handleEmailNotifications(form, cleanedFormData).catch((error) => {
-          console.error('Failed to send submission notification email', error);
-        }),
+        handleEmailNotifications(form, cleanedFormData).catch(
+          (error: unknown) => {
+            console.error(
+              'Failed to send submission notification email',
+              error,
+            );
+          },
+        ),
       );
     }
 
-    if (!spamResult.isSpam && form.enableWebhook && form.webhookUrl) {
-      const { env } = getCloudflareContext();
-      const queue = env.WEBHOOK_QUEUE;
-      const webhookUrl = form.webhookUrl;
+    if (!spamResult.isSpam) {
       after(() =>
-        enqueueWebhook(queue, {
+        enqueueWebhook({
           formId,
           formDataId,
-          webhookUrl,
         }).catch((error: unknown) => {
           console.error('Failed to enqueue webhook', error);
         }),

--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -2,12 +2,15 @@ import { type NextRequest } from 'next/server';
 
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
 import { appRouter, createTRPCContext } from '@formbase/api';
 import { env } from '@formbase/env';
 
 const createContext = async (req: NextRequest) => {
   return createTRPCContext({
     headers: req.headers,
+    webhookQueue: getCloudflareContext().env.WEBHOOK_QUEUE,
   });
 };
 

--- a/apps/web/src/cloudflare-bindings.d.ts
+++ b/apps/web/src/cloudflare-bindings.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface CloudflareEnv {
+    WEBHOOK_QUEUE: Queue;
+  }
+}
+
+export {};

--- a/apps/web/src/cloudflare-bindings.d.ts
+++ b/apps/web/src/cloudflare-bindings.d.ts
@@ -1,6 +1,8 @@
+import type { WebhookQueue } from '@formbase/api/lib/webhook';
+
 declare global {
   interface CloudflareEnv {
-    WEBHOOK_QUEUE: Queue;
+    WEBHOOK_QUEUE: WebhookQueue;
   }
 }
 

--- a/apps/web/src/lib/trpc/server.ts
+++ b/apps/web/src/lib/trpc/server.ts
@@ -3,6 +3,8 @@ import 'server-only';
 import { cache } from 'react';
 import { headers } from 'next/headers';
 
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
 import { createCaller, createTRPCContext } from '@formbase/api';
 
 const createContext = cache(async () => {
@@ -11,6 +13,7 @@ const createContext = cache(async () => {
 
   return createTRPCContext({
     headers: heads,
+    webhookQueue: getCloudflareContext().env.WEBHOOK_QUEUE,
   });
 });
 

--- a/apps/web/src/lib/webhooks/consumer.ts
+++ b/apps/web/src/lib/webhooks/consumer.ts
@@ -1,0 +1,82 @@
+import type {
+  WebhookPayload,
+  WebhookQueueMessage,
+} from '@formbase/api/lib/webhook';
+
+import { db } from '@formbase/db';
+import {
+  getDeliveryLog,
+  getWebhookSecret,
+  markFailed,
+  markPending,
+  markSuccess,
+} from '@formbase/api/lib/webhook';
+
+import { deliverWebhook } from './deliver';
+
+const BACKOFF_S = [60, 600, 3600, 21600, 43200];
+
+type WebhookMessage = {
+  body: WebhookQueueMessage;
+  attempts: number;
+  ack(): void;
+  retry(opts?: { delaySeconds?: number }): void;
+};
+
+export async function handleWebhookBatch(
+  batch: { queue: string; messages: WebhookMessage[] },
+  _env: unknown,
+  _ctx: unknown,
+): Promise<void> {
+  if (batch.queue.endsWith('-dlq')) {
+    for (const msg of batch.messages) {
+      await markFailed(db, msg.body.deliveryLogId, {
+        error: 'Exhausted retries (moved to DLQ)',
+      });
+      msg.ack();
+    }
+    return;
+  }
+
+  for (const msg of batch.messages) {
+    const { deliveryLogId } = msg.body;
+    try {
+      const log = await getDeliveryLog(db, deliveryLogId);
+      if (!log || log.status === 'success') {
+        msg.ack();
+        continue;
+      }
+
+      const secret = await getWebhookSecret(db, log.formId);
+      const result = await deliverWebhook({
+        webhookUrl: log.webhookUrl,
+        payload: JSON.parse(log.payload) as WebhookPayload,
+        secret,
+      });
+      const attempt = msg.attempts;
+
+      if (result.success) {
+        await markSuccess(db, deliveryLogId, {
+          statusCode: result.statusCode ?? 0,
+          ...(result.body !== undefined && { body: result.body }),
+        });
+        msg.ack();
+      } else {
+        const delay =
+          BACKOFF_S[Math.min(attempt - 1, BACKOFF_S.length - 1)] ?? 60;
+        await markPending(
+          db,
+          deliveryLogId,
+          result,
+          new Date(Date.now() + delay * 1000),
+        );
+        msg.retry({ delaySeconds: delay });
+      }
+    } catch {
+      const attempt = msg.attempts;
+      const delay =
+        BACKOFF_S[Math.min(attempt - 1, BACKOFF_S.length - 1)] ?? 60;
+      msg.retry({ delaySeconds: delay });
+    }
+  }
+}

--- a/apps/web/src/lib/webhooks/consumer.ts
+++ b/apps/web/src/lib/webhooks/consumer.ts
@@ -30,10 +30,15 @@ export async function handleWebhookBatch(
 ): Promise<void> {
   if (batch.queue.endsWith('-dlq')) {
     for (const msg of batch.messages) {
-      await markFailed(db, msg.body.deliveryLogId, {
-        error: 'Exhausted retries (moved to DLQ)',
-      });
-      msg.ack();
+      try {
+        await markFailed(db, msg.body.deliveryLogId, {
+          error: 'Exhausted retries (moved to DLQ)',
+        });
+      } catch (error) {
+        console.error('Failed to mark webhook delivery as failed', error);
+      } finally {
+        msg.ack();
+      }
     }
     return;
   }

--- a/apps/web/src/lib/webhooks/deliver.ts
+++ b/apps/web/src/lib/webhooks/deliver.ts
@@ -1,0 +1,76 @@
+import type { WebhookPayload } from '@formbase/api/lib/webhook';
+
+const WEBHOOK_TIMEOUT_MS = 10000;
+
+async function signBody(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(message),
+  );
+  return [...new Uint8Array(signature)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function deliverWebhook({
+  webhookUrl,
+  payload,
+  secret,
+}: {
+  webhookUrl: string;
+  payload: WebhookPayload;
+  secret: string | null;
+}): Promise<{
+  success: boolean;
+  statusCode?: number;
+  body?: string;
+  error?: string;
+}> {
+  const body = JSON.stringify(payload);
+  const timestamp = String(Date.now());
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'X-Formbase-Event': payload.event,
+    'X-Formbase-Timestamp': timestamp,
+  };
+
+  if (secret) {
+    headers['X-Formbase-Signature'] =
+      'sha256=' + (await signBody(secret, timestamp + '.' + body));
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, WEBHOOK_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers,
+      body,
+      signal: controller.signal,
+    });
+    const responseBody = await response.text();
+    return {
+      success: response.ok,
+      statusCode: response.status,
+      body: responseBody,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/web/src/lib/webhooks/producer.ts
+++ b/apps/web/src/lib/webhooks/producer.ts
@@ -1,0 +1,29 @@
+import type { WebhookQueue } from '@formbase/api/lib/webhook';
+
+import { db } from '@formbase/db';
+import {
+  buildWebhookPayload,
+  createDeliveryLogRow,
+} from '@formbase/api/lib/webhook';
+
+export async function enqueueWebhook(
+  queue: WebhookQueue,
+  {
+    formId,
+    formDataId,
+    webhookUrl,
+  }: { formId: string; formDataId: string; webhookUrl: string },
+): Promise<string | null> {
+  const payload = await buildWebhookPayload(db, formId, formDataId);
+  if (!payload) return null;
+
+  const deliveryLogId = await createDeliveryLogRow(db, {
+    formId,
+    formDataId,
+    webhookUrl,
+    payload,
+  });
+
+  await queue.send({ deliveryLogId, webhookUrl });
+  return deliveryLogId;
+}

--- a/apps/web/src/lib/webhooks/producer.ts
+++ b/apps/web/src/lib/webhooks/producer.ts
@@ -1,19 +1,29 @@
-import type { WebhookQueue } from '@formbase/api/lib/webhook';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
 
-import { db } from '@formbase/db';
 import {
   buildWebhookPayload,
   createDeliveryLogRow,
 } from '@formbase/api/lib/webhook';
+import { db, drizzlePrimitives } from '@formbase/db';
+import { forms } from '@formbase/db/schema';
 
-export async function enqueueWebhook(
-  queue: WebhookQueue,
-  {
-    formId,
-    formDataId,
-    webhookUrl,
-  }: { formId: string; formDataId: string; webhookUrl: string },
-): Promise<string | null> {
+const { eq } = drizzlePrimitives;
+
+export async function enqueueWebhook({
+  formId,
+  formDataId,
+}: {
+  formId: string;
+  formDataId: string;
+}): Promise<string | null> {
+  const form = await db.query.forms.findFirst({
+    where: eq(forms.id, formId),
+    columns: { enableWebhook: true, webhookUrl: true },
+  });
+  if (!form?.enableWebhook || !form.webhookUrl) return null;
+
+  const webhookUrl = form.webhookUrl;
+
   const payload = await buildWebhookPayload(db, formId, formDataId);
   if (!payload) return null;
 
@@ -24,6 +34,7 @@ export async function enqueueWebhook(
     payload,
   });
 
+  const { WEBHOOK_QUEUE: queue } = getCloudflareContext().env;
   await queue.send({ deliveryLogId, webhookUrl });
   return deliveryLogId;
 }

--- a/apps/web/src/lib/webhooks/scheduled.ts
+++ b/apps/web/src/lib/webhooks/scheduled.ts
@@ -1,15 +1,18 @@
 import type { WebhookQueue } from '@formbase/api/lib/webhook';
 
-import { db } from '@formbase/db';
 import {
   cleanupOldWebhookLogs,
   findStuckDeliveries,
 } from '@formbase/api/lib/webhook';
+import { db } from '@formbase/db';
+
+const SWEEP_BATCH_SIZE = 100;
 
 async function sweepStuckWebhooks(queue: WebhookQueue): Promise<void> {
   const stuck = await findStuckDeliveries(db, {
     olderThanMs: 120000,
     leaseMs: 900000,
+    limit: SWEEP_BATCH_SIZE,
   });
   if (stuck.length) {
     await queue.sendBatch(

--- a/apps/web/src/lib/webhooks/scheduled.ts
+++ b/apps/web/src/lib/webhooks/scheduled.ts
@@ -1,0 +1,36 @@
+import type { WebhookQueue } from '@formbase/api/lib/webhook';
+
+import { db } from '@formbase/db';
+import {
+  cleanupOldWebhookLogs,
+  findStuckDeliveries,
+} from '@formbase/api/lib/webhook';
+
+async function sweepStuckWebhooks(queue: WebhookQueue): Promise<void> {
+  const stuck = await findStuckDeliveries(db, {
+    olderThanMs: 120000,
+    leaseMs: 900000,
+  });
+  if (stuck.length) {
+    await queue.sendBatch(
+      stuck.map((s) => ({
+        body: { deliveryLogId: s.id, webhookUrl: s.webhookUrl },
+      })),
+    );
+  }
+}
+
+export async function handleScheduled(
+  controller: { cron: string },
+  env: { WEBHOOK_QUEUE: WebhookQueue },
+  _ctx: unknown,
+): Promise<void> {
+  switch (controller.cron) {
+    case '*/5 * * * *':
+      await sweepStuckWebhooks(env.WEBHOOK_QUEUE);
+      break;
+    case '0 3 * * *':
+      await cleanupOldWebhookLogs(db);
+      break;
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": ["@formbase/tsconfig/next.json"],
   "compilerOptions": {
+    "checkJs": false,
     "paths": {
       "~/*": ["./src/*"]
     }

--- a/apps/web/worker.ts
+++ b/apps/web/worker.ts
@@ -1,0 +1,32 @@
+// @ts-ignore generated at build time
+import { default as handler } from './.open-next/worker.js';
+// @ts-ignore generated at build time
+export {
+  DOQueueHandler,
+  DOShardedTagCache,
+  BucketCachePurge,
+} from './.open-next/worker.js';
+
+function hydrateProcessEnv(env: Record<string, unknown>) {
+  for (const [k, v] of Object.entries(env)) {
+    if (typeof v === 'string') process.env[k] = v;
+  }
+}
+
+export default {
+  fetch: handler.fetch,
+  async queue(batch: unknown, env: Record<string, unknown>, ctx: unknown) {
+    hydrateProcessEnv(env);
+    const { handleWebhookBatch } = await import('./src/lib/webhooks/consumer');
+    await handleWebhookBatch(batch as never, env, ctx);
+  },
+  async scheduled(
+    controller: { cron: string },
+    env: Record<string, unknown>,
+    ctx: unknown,
+  ) {
+    hydrateProcessEnv(env);
+    const { handleScheduled } = await import('./src/lib/webhooks/scheduled');
+    await handleScheduled(controller, env as never, ctx);
+  },
+};

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "formbase-web",
-  "main": ".open-next/worker.js",
+  "main": "./worker.ts",
   "workers_dev": true,
   "preview_urls": false,
   "compatibility_date": "2026-05-01",
@@ -27,5 +27,33 @@
   },
   "observability": {
     "enabled": true,
+  },
+  "queues": {
+    "producers": [
+      {
+        "queue": "formbase-webhooks",
+        "binding": "WEBHOOK_QUEUE",
+      },
+    ],
+    "consumers": [
+      {
+        "queue": "formbase-webhooks",
+        "max_batch_size": 10,
+        "max_batch_timeout": 5,
+        "max_retries": 5,
+        "max_concurrency": 5,
+        "dead_letter_queue": "formbase-webhooks-dlq",
+        "retry_delay": 60,
+      },
+      {
+        "queue": "formbase-webhooks-dlq",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30,
+        "max_retries": 1,
+      },
+    ],
+  },
+  "triggers": {
+    "crons": ["*/5 * * * *", "0 3 * * *"],
   },
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+linker = "hoisted"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,8 @@ export default [
       '**/test-results/**',
       '**/playwright-report/**',
       'apps/web/next-env.d.ts',
+      'apps/web/cloudflare-env.d.ts',
+      'apps/web/worker.ts',
       'packages/core/.tsup/**',
     ],
   },

--- a/packages/api/lib/webhook.ts
+++ b/packages/api/lib/webhook.ts
@@ -1,0 +1,276 @@
+import type { db as database } from '@formbase/db';
+import type { WebhookDeliveryLog } from '@formbase/db/schema';
+
+import { drizzlePrimitives } from '@formbase/db';
+import { formDatas, forms, webhookDeliveryLogs } from '@formbase/db/schema';
+import { generateId } from '@formbase/utils/generate-id';
+
+import { parseJsonObject } from '../utils/json';
+
+type Database = typeof database;
+
+const { and, eq, isNull, lt, or, sql } = drizzlePrimitives;
+
+export const SUBMISSION_CREATED = 'submission.created';
+
+export interface WebhookPayload {
+  event: 'submission.created';
+  payload: {
+    id: string;
+    formId: string;
+    formTitle: string;
+    data: Record<string, unknown>;
+    fileUrls: string[];
+    isSpam: boolean;
+    spamReason: string | null;
+    createdAt: string;
+  };
+}
+
+export interface WebhookQueueMessage {
+  deliveryLogId: string;
+  webhookUrl: string;
+}
+
+export interface WebhookQueue {
+  send(message: WebhookQueueMessage): Promise<unknown>;
+  sendBatch(messages: Array<{ body: WebhookQueueMessage }>): Promise<unknown>;
+}
+
+function truncate(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  return value.slice(0, 10000);
+}
+
+export async function buildWebhookPayload(
+  db: Database,
+  formId: string,
+  formDataId: string,
+): Promise<WebhookPayload | null> {
+  const form = await db.query.forms.findFirst({
+    where: eq(forms.id, formId),
+    columns: { id: true, title: true },
+  });
+
+  if (!form) return null;
+
+  const submission = await db.query.formDatas.findFirst({
+    where: eq(formDatas.id, formDataId),
+    columns: {
+      id: true,
+      data: true,
+      isSpam: true,
+      spamReason: true,
+      createdAt: true,
+    },
+  });
+
+  if (!submission) return null;
+
+  const data = parseJsonObject(submission.data) ?? {};
+  const fileUrls = Object.values(data).filter(
+    (value): value is string =>
+      typeof value === 'string' && value.startsWith('http'),
+  );
+
+  return {
+    event: SUBMISSION_CREATED,
+    payload: {
+      id: submission.id,
+      formId: form.id,
+      formTitle: form.title,
+      data,
+      fileUrls,
+      isSpam: submission.isSpam,
+      spamReason: submission.spamReason,
+      createdAt: submission.createdAt.toISOString(),
+    },
+  };
+}
+
+export function buildMockPayload(form: {
+  id: string;
+  title: string;
+}): WebhookPayload {
+  return {
+    event: SUBMISSION_CREATED,
+    payload: {
+      id: `test_${generateId(10)}`,
+      formId: form.id,
+      formTitle: form.title,
+      data: { message: 'This is a test webhook from formbase' },
+      fileUrls: [],
+      isSpam: false,
+      spamReason: null,
+      createdAt: new Date().toISOString(),
+    },
+  };
+}
+
+export async function createDeliveryLogRow(
+  db: Database,
+  {
+    formId,
+    formDataId,
+    webhookUrl,
+    payload,
+  }: {
+    formId: string;
+    formDataId: string | null;
+    webhookUrl: string;
+    payload: WebhookPayload;
+  },
+): Promise<string> {
+  const id = generateId(15);
+  await db.insert(webhookDeliveryLogs).values({
+    id,
+    formId,
+    formDataId,
+    webhookUrl,
+    payload: JSON.stringify(payload),
+    status: 'pending',
+    attempts: 0,
+  });
+  return id;
+}
+
+export async function getDeliveryLog(
+  db: Database,
+  id: string,
+): Promise<WebhookDeliveryLog | undefined> {
+  return db.query.webhookDeliveryLogs.findFirst({
+    where: eq(webhookDeliveryLogs.id, id),
+  });
+}
+
+export async function getWebhookSecret(
+  db: Database,
+  formId: string,
+): Promise<string | null> {
+  const form = await db.query.forms.findFirst({
+    where: eq(forms.id, formId),
+    columns: { webhookSecret: true },
+  });
+  return form?.webhookSecret ?? null;
+}
+
+export async function markSuccess(
+  db: Database,
+  id: string,
+  { statusCode, body }: { statusCode: number; body?: string },
+) {
+  await db
+    .update(webhookDeliveryLogs)
+    .set({
+      status: 'success',
+      statusCode,
+      responseBody: truncate(body),
+      completedAt: new Date(),
+      attempts: sql`${webhookDeliveryLogs.attempts} + 1`,
+    })
+    .where(eq(webhookDeliveryLogs.id, id));
+}
+
+export async function markPending(
+  db: Database,
+  id: string,
+  result: { statusCode?: number; body?: string; error?: string },
+  nextRetryAt: Date,
+) {
+  await db
+    .update(webhookDeliveryLogs)
+    .set({
+      status: 'pending',
+      statusCode: result.statusCode ?? null,
+      responseBody: truncate(result.body),
+      errorMessage: result.error ?? null,
+      nextRetryAt,
+      attempts: sql`${webhookDeliveryLogs.attempts} + 1`,
+    })
+    .where(eq(webhookDeliveryLogs.id, id));
+}
+
+export async function markFailed(
+  db: Database,
+  id: string,
+  result: { statusCode?: number; body?: string; error?: string },
+) {
+  await db
+    .update(webhookDeliveryLogs)
+    .set({
+      status: 'failed',
+      statusCode: result.statusCode ?? null,
+      responseBody: truncate(result.body),
+      errorMessage: result.error ?? null,
+      completedAt: new Date(),
+      attempts: sql`${webhookDeliveryLogs.attempts} + 1`,
+    })
+    .where(eq(webhookDeliveryLogs.id, id));
+}
+
+export async function findStuckDeliveries(
+  db: Database,
+  { olderThanMs, leaseMs }: { olderThanMs: number; leaseMs: number },
+): Promise<Array<{ id: string; webhookUrl: string }>> {
+  const now = new Date();
+  const staleBefore = new Date(now.getTime() - leaseMs);
+  const nextRetryAt = new Date(now.getTime() + leaseMs);
+  return db
+    .update(webhookDeliveryLogs)
+    .set({ nextRetryAt })
+    .where(
+      and(
+        eq(webhookDeliveryLogs.status, 'pending'),
+        lt(webhookDeliveryLogs.attempts, 5),
+        or(
+          isNull(webhookDeliveryLogs.nextRetryAt),
+          lt(webhookDeliveryLogs.nextRetryAt, staleBefore),
+        ),
+        lt(
+          webhookDeliveryLogs.createdAt,
+          new Date(now.getTime() - olderThanMs),
+        ),
+      ),
+    )
+    .returning({
+      id: webhookDeliveryLogs.id,
+      webhookUrl: webhookDeliveryLogs.webhookUrl,
+    });
+}
+
+export async function cleanupOldWebhookLogs(db: Database) {
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+  await db
+    .delete(webhookDeliveryLogs)
+    .where(
+      and(
+        drizzlePrimitives.inArray(webhookDeliveryLogs.status, [
+          'success',
+          'failed',
+        ]),
+        lt(webhookDeliveryLogs.createdAt, ninetyDaysAgo),
+      ),
+    );
+}
+
+export async function listWebhookDeliveries(
+  db: Database,
+  formId: string,
+  limit = 20,
+) {
+  return db
+    .select({
+      id: webhookDeliveryLogs.id,
+      status: webhookDeliveryLogs.status,
+      statusCode: webhookDeliveryLogs.statusCode,
+      attempts: webhookDeliveryLogs.attempts,
+      webhookUrl: webhookDeliveryLogs.webhookUrl,
+      errorMessage: webhookDeliveryLogs.errorMessage,
+      createdAt: webhookDeliveryLogs.createdAt,
+      completedAt: webhookDeliveryLogs.completedAt,
+    })
+    .from(webhookDeliveryLogs)
+    .where(eq(webhookDeliveryLogs.formId, formId))
+    .orderBy(sql`${webhookDeliveryLogs.createdAt} desc`)
+    .limit(limit);
+}

--- a/packages/api/lib/webhook.ts
+++ b/packages/api/lib/webhook.ts
@@ -9,7 +9,7 @@ import { parseJsonObject } from '../utils/json';
 
 type Database = typeof database;
 
-const { and, eq, isNull, lt, or, sql } = drizzlePrimitives;
+const { and, eq, inArray, isNull, lt, or, sql } = drizzlePrimitives;
 
 export const SUBMISSION_CREATED = 'submission.created';
 
@@ -34,7 +34,9 @@ export interface WebhookQueueMessage {
 
 export interface WebhookQueue {
   send(message: WebhookQueueMessage): Promise<unknown>;
-  sendBatch(messages: Array<{ body: WebhookQueueMessage }>): Promise<unknown>;
+  sendBatch(
+    messages: Iterable<{ body: WebhookQueueMessage }>,
+  ): Promise<unknown>;
 }
 
 function truncate(value: string | undefined): string | null {
@@ -210,26 +212,42 @@ export async function markFailed(
 
 export async function findStuckDeliveries(
   db: Database,
-  { olderThanMs, leaseMs }: { olderThanMs: number; leaseMs: number },
+  {
+    olderThanMs,
+    leaseMs,
+    limit = 100,
+  }: { olderThanMs: number; leaseMs: number; limit?: number },
 ): Promise<Array<{ id: string; webhookUrl: string }>> {
   const now = new Date();
   const staleBefore = new Date(now.getTime() - leaseMs);
   const nextRetryAt = new Date(now.getTime() + leaseMs);
+  const eligibleDeliveries = and(
+    eq(webhookDeliveryLogs.status, 'pending'),
+    lt(webhookDeliveryLogs.attempts, 5),
+    or(
+      isNull(webhookDeliveryLogs.nextRetryAt),
+      lt(webhookDeliveryLogs.nextRetryAt, staleBefore),
+    ),
+    lt(webhookDeliveryLogs.createdAt, new Date(now.getTime() - olderThanMs)),
+  );
+  const candidates = await db
+    .select({ id: webhookDeliveryLogs.id })
+    .from(webhookDeliveryLogs)
+    .where(eligibleDeliveries)
+    .limit(Math.min(limit, 100));
+
+  if (!candidates.length) return [];
+
   return db
     .update(webhookDeliveryLogs)
     .set({ nextRetryAt })
     .where(
       and(
-        eq(webhookDeliveryLogs.status, 'pending'),
-        lt(webhookDeliveryLogs.attempts, 5),
-        or(
-          isNull(webhookDeliveryLogs.nextRetryAt),
-          lt(webhookDeliveryLogs.nextRetryAt, staleBefore),
+        inArray(
+          webhookDeliveryLogs.id,
+          candidates.map((candidate) => candidate.id),
         ),
-        lt(
-          webhookDeliveryLogs.createdAt,
-          new Date(now.getTime() - olderThanMs),
-        ),
+        eligibleDeliveries,
       ),
     )
     .returning({

--- a/packages/api/routers/form.ts
+++ b/packages/api/routers/form.ts
@@ -1,20 +1,20 @@
-import { TRPCError } from "@trpc/server";
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
 
-import { drizzlePrimitives } from "@formbase/db";
-import { formDatas, forms, onboardingForms } from "@formbase/db/schema";
-import { generateId } from "@formbase/utils/generate-id";
-import { isValidWebhookUrl } from "@formbase/utils/webhook";
-import { z } from "zod";
+import { drizzlePrimitives } from '@formbase/db';
+import { formDatas, forms, onboardingForms } from '@formbase/db/schema';
+import { generateId } from '@formbase/utils/generate-id';
+import { isValidWebhookUrl } from '@formbase/utils/webhook';
 
 import {
   buildMockPayload,
   buildWebhookPayload,
   createDeliveryLogRow,
   listWebhookDeliveries,
-} from "../lib/webhook";
-import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
-import { parseJsonArray, serializeJson } from "../utils/json";
-import { assertFormOwnership } from "./form-ownership";
+} from '../lib/webhook';
+import { createTRPCRouter, protectedProcedure, publicProcedure } from '../trpc';
+import { parseJsonArray, serializeJson } from '../utils/json';
+import { assertFormOwnership } from './form-ownership';
 
 const { and, count, eq } = drizzlePrimitives;
 
@@ -142,7 +142,7 @@ export const formRouter = createTRPCRouter({
           .url()
           .refine(isValidWebhookUrl, {
             message:
-              "Webhook URL must use HTTPS (localhost allowed only in development)",
+              'Webhook URL must use HTTPS (localhost allowed only in development)',
           })
           .optional()
           .nullable(),
@@ -154,7 +154,7 @@ export const formRouter = createTRPCRouter({
       const enablingWebhook =
         input.enableWebhook === true && !form.webhookSecret;
       const webhookSecret = enablingWebhook
-        ? (crypto.randomUUID() + crypto.randomUUID()).replace(/-/g, "")
+        ? (crypto.randomUUID() + crypto.randomUUID()).replace(/-/g, '')
         : undefined;
 
       await ctx.db
@@ -288,8 +288,6 @@ export const formRouter = createTRPCRouter({
           enableRetention: true,
           defaultSubmissionEmail: true,
           honeypotField: true,
-          enableWebhook: true,
-          webhookUrl: true,
         },
       });
 
@@ -308,15 +306,15 @@ export const formRouter = createTRPCRouter({
 
       if (!form.enableWebhook || !form.webhookUrl) {
         throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Webhook is not enabled or URL is not configured",
+          code: 'BAD_REQUEST',
+          message: 'Webhook is not enabled or URL is not configured',
         });
       }
 
       if (!ctx.webhookQueue) {
         throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Webhook queue unavailable",
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Webhook queue unavailable',
         });
       }
 
@@ -336,7 +334,10 @@ export const formRouter = createTRPCRouter({
         payload,
       });
 
-      await ctx.webhookQueue.send({ deliveryLogId, webhookUrl: form.webhookUrl });
+      await ctx.webhookQueue.send({
+        deliveryLogId,
+        webhookUrl: form.webhookUrl,
+      });
 
       return { deliveryLogId };
     }),

--- a/packages/api/routers/form.ts
+++ b/packages/api/routers/form.ts
@@ -1,8 +1,17 @@
+import { TRPCError } from "@trpc/server";
+
 import { drizzlePrimitives } from "@formbase/db";
 import { formDatas, forms, onboardingForms } from "@formbase/db/schema";
 import { generateId } from "@formbase/utils/generate-id";
+import { isValidWebhookUrl } from "@formbase/utils/webhook";
 import { z } from "zod";
 
+import {
+  buildMockPayload,
+  buildWebhookPayload,
+  createDeliveryLogRow,
+  listWebhookDeliveries,
+} from "../lib/webhook";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { parseJsonArray, serializeJson } from "../utils/json";
 import { assertFormOwnership } from "./form-ownership";
@@ -127,10 +136,26 @@ export const formRouter = createTRPCRouter({
         returnUrl: z.string().optional(),
         defaultSubmissionEmail: z.string().optional(),
         honeypotField: z.string().optional(),
+        enableWebhook: z.boolean().optional(),
+        webhookUrl: z
+          .string()
+          .url()
+          .refine(isValidWebhookUrl, {
+            message:
+              "Webhook URL must use HTTPS (localhost allowed only in development)",
+          })
+          .optional()
+          .nullable(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
       const form = await assertFormOwnership(ctx, input.id);
+
+      const enablingWebhook =
+        input.enableWebhook === true && !form.webhookSecret;
+      const webhookSecret = enablingWebhook
+        ? (crypto.randomUUID() + crypto.randomUUID()).replace(/-/g, "")
+        : undefined;
 
       await ctx.db
         .update(forms)
@@ -145,6 +170,10 @@ export const formRouter = createTRPCRouter({
           defaultSubmissionEmail:
             input.defaultSubmissionEmail ?? form.defaultSubmissionEmail,
           honeypotField: input.honeypotField ?? form.honeypotField,
+          enableWebhook: input.enableWebhook ?? form.enableWebhook,
+          webhookUrl:
+            input.webhookUrl !== undefined ? input.webhookUrl : form.webhookUrl,
+          ...(webhookSecret ? { webhookSecret } : {}),
         })
         .where(eq(forms.id, input.id));
     }),
@@ -245,6 +274,23 @@ export const formRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const form = await ctx.db.query.forms.findFirst({
         where: (table) => eq(table.id, input.formId),
+        columns: {
+          id: true,
+          userId: true,
+          title: true,
+          description: true,
+          createdAt: true,
+          updatedAt: true,
+          returnUrl: true,
+          enableEmailNotifications: true,
+          keys: true,
+          enableSubmissions: true,
+          enableRetention: true,
+          defaultSubmissionEmail: true,
+          honeypotField: true,
+          enableWebhook: true,
+          webhookUrl: true,
+        },
       });
 
       if (!form) return null;
@@ -253,5 +299,57 @@ export const formRouter = createTRPCRouter({
         ...form,
         keys: parseJsonArray(form.keys),
       };
+    }),
+
+  testWebhook: protectedProcedure
+    .input(z.object({ formId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const form = await assertFormOwnership(ctx, input.formId);
+
+      if (!form.enableWebhook || !form.webhookUrl) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Webhook is not enabled or URL is not configured",
+        });
+      }
+
+      if (!ctx.webhookQueue) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Webhook queue unavailable",
+        });
+      }
+
+      const latest = await ctx.db.query.formDatas.findFirst({
+        where: (table) => eq(table.formId, form.id),
+        orderBy: (table, { desc }) => desc(table.createdAt),
+      });
+
+      const payload =
+        (latest && (await buildWebhookPayload(ctx.db, form.id, latest.id))) ??
+        buildMockPayload({ id: form.id, title: form.title });
+
+      const deliveryLogId = await createDeliveryLogRow(ctx.db, {
+        formId: form.id,
+        formDataId: latest?.id ?? null,
+        webhookUrl: form.webhookUrl,
+        payload,
+      });
+
+      await ctx.webhookQueue.send({ deliveryLogId, webhookUrl: form.webhookUrl });
+
+      return { deliveryLogId };
+    }),
+
+  listDeliveries: protectedProcedure
+    .input(
+      z.object({
+        formId: z.string(),
+        limit: z.number().min(1).max(100).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertFormOwnership(ctx, input.formId);
+      return listWebhookDeliveries(ctx.db, input.formId, input.limit ?? 20);
     }),
 });

--- a/packages/api/routers/formData.ts
+++ b/packages/api/routers/formData.ts
@@ -120,11 +120,13 @@ export const formDataRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const [formdata] = await ctx.db.batch([
+      const id = generateId(15);
+
+      await ctx.db.batch([
         ctx.db.insert(formDatas).values({
           data: serializeJson(input.data),
           formId: input.formId,
-          id: generateId(15),
+          id,
           createdAt: new Date(),
           isSpam: input.isSpam,
           spamReason: input.spamReason ?? null,
@@ -138,7 +140,7 @@ export const formDataRouter = createTRPCRouter({
           .where(eq(forms.id, input.formId)),
       ]);
 
-      return formdata;
+      return { id };
     }),
 
   markAsSpam: protectedProcedure

--- a/packages/api/trpc.ts
+++ b/packages/api/trpc.ts
@@ -5,7 +5,12 @@ import { ZodError } from 'zod';
 import { getSession } from '@formbase/auth/server';
 import { db } from '@formbase/db';
 
-export const createTRPCContext = async (opts: { headers: Headers }) => {
+import type { WebhookQueue } from './lib/webhook';
+
+export const createTRPCContext = async (opts: {
+  headers: Headers;
+  webhookQueue?: WebhookQueue;
+}) => {
   const session = await getSession();
   const user = session?.user ?? null;
 
@@ -13,6 +18,7 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
     db,
     session,
     user,
+    webhookQueue: opts.webhookQueue,
     ...opts,
   };
 };

--- a/packages/db/drizzle/0003_awesome_inhumans.sql
+++ b/packages/db/drizzle/0003_awesome_inhumans.sql
@@ -1,0 +1,24 @@
+CREATE TABLE `webhook_delivery_logs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`form_id` text NOT NULL,
+	`form_data_id` text,
+	`webhook_url` text NOT NULL,
+	`payload` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`status_code` integer,
+	`response_body` text,
+	`error_message` text,
+	`attempts` integer DEFAULT 0 NOT NULL,
+	`next_retry_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`completed_at` integer,
+	FOREIGN KEY (`form_id`) REFERENCES `forms`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`form_data_id`) REFERENCES `form_datas`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `webhook_log_form_idx` ON `webhook_delivery_logs` (`form_id`);--> statement-breakpoint
+CREATE INDEX `webhook_log_status_idx` ON `webhook_delivery_logs` (`status`);--> statement-breakpoint
+CREATE INDEX `webhook_log_next_retry_idx` ON `webhook_delivery_logs` (`next_retry_at`);--> statement-breakpoint
+ALTER TABLE `forms` ADD `enable_webhook` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `forms` ADD `webhook_url` text;--> statement-breakpoint
+ALTER TABLE `forms` ADD `webhook_secret` text;

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1081 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e5a2551b-fbc6-4b6b-8a86-1a8d86b5a3e3",
+  "prevId": "57d4c97e-b93c-4e5d-977d-b619497f66a1",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_idx": {
+          "name": "account_provider_account_idx",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_audit_logs": {
+      "name": "api_audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "audit_api_key_idx": {
+          "name": "audit_api_key_idx",
+          "columns": [
+            "api_key_id"
+          ],
+          "isUnique": false
+        },
+        "audit_user_idx": {
+          "name": "audit_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "audit_created_at_idx": {
+          "name": "audit_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_audit_logs_api_key_id_api_keys_id_fk": {
+          "name": "api_audit_logs_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_audit_logs",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "api_key_user_idx": {
+          "name": "api_key_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_key_hash_idx": {
+          "name": "api_key_hash_idx",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_user_id_fk": {
+          "name": "api_keys_user_id_user_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "form_datas": {
+      "name": "form_datas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "is_spam": {
+          "name": "is_spam",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "spam_reason": {
+          "name": "spam_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "form_idx": {
+          "name": "form_idx",
+          "columns": [
+            "form_id"
+          ],
+          "isUnique": false
+        },
+        "form_data_created_at_idx": {
+          "name": "form_data_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "form_datas_form_id_forms_id_fk": {
+          "name": "form_datas_form_id_forms_id_fk",
+          "tableFrom": "form_datas",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms": {
+      "name": "forms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_url": {
+          "name": "return_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "send_email_for_new_submissions": {
+          "name": "send_email_for_new_submissions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "keys": {
+          "name": "keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enable_submissions": {
+          "name": "enable_submissions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enable_retention": {
+          "name": "enable_retention",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "default_submission_email": {
+          "name": "default_submission_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "honeypot_field": {
+          "name": "honeypot_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_gotcha'"
+        },
+        "enable_webhook": {
+          "name": "enable_webhook",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "form_user_idx": {
+          "name": "form_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "form_created_at_idx": {
+          "name": "form_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_user_id_user_id_fk": {
+          "name": "forms_user_id_user_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "onboarding_forms": {
+      "name": "onboarding_forms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "onboarding_forms_user_id_user_id_fk": {
+          "name": "onboarding_forms_user_id_user_id_fk",
+          "tableFrom": "onboarding_forms",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_forms_form_id_forms_id_fk": {
+          "name": "onboarding_forms_form_id_forms_id_fk",
+          "tableFrom": "onboarding_forms",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_delivery_logs": {
+      "name": "webhook_delivery_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_data_id": {
+          "name": "form_data_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_log_form_idx": {
+          "name": "webhook_log_form_idx",
+          "columns": [
+            "form_id"
+          ],
+          "isUnique": false
+        },
+        "webhook_log_status_idx": {
+          "name": "webhook_log_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_log_next_retry_idx": {
+          "name": "webhook_log_next_retry_idx",
+          "columns": [
+            "next_retry_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_logs_form_id_forms_id_fk": {
+          "name": "webhook_delivery_logs_form_id_forms_id_fk",
+          "tableFrom": "webhook_delivery_logs",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_delivery_logs_form_data_id_form_datas_id_fk": {
+          "name": "webhook_delivery_logs_form_data_id_form_datas_id_fk",
+          "tableFrom": "webhook_delivery_logs",
+          "tableTo": "form_datas",
+          "columnsFrom": [
+            "form_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1768165812454,
       "tag": "0002_majestic_the_hood",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1780431327310,
+      "tag": "0003_awesome_inhumans",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "db:check": "dotenv -e ../../apps/web/.env.local drizzle-kit check",
     "db:generate": "dotenv -e ../../apps/web/.env.local drizzle-kit generate",
-    "db:migrate": "dotenv -e ../../apps/web/.env.local pnpm tsx migrate.ts",
+    "db:migrate": "dotenv -e ../../apps/web/.env.local tsx migrate.ts",
     "db:migrate:drop": "dotenv -e ../../apps/web/.env.local drizzle-kit drop",
     "db:pull": "dotenv -e ../../apps/web/.env.local drizzle-kit introspect",
     "db:push": "dotenv -e ../../apps/web/.env.local drizzle-kit push",

--- a/packages/db/schema/forms.ts
+++ b/packages/db/schema/forms.ts
@@ -38,6 +38,13 @@ export const forms = sqliteTable(
       .notNull(),
     defaultSubmissionEmail: text('default_submission_email'),
     honeypotField: text('honeypot_field').default('_gotcha').notNull(),
+    enableWebhook: integer('enable_webhook', {
+      mode: 'boolean',
+    })
+      .default(false)
+      .notNull(),
+    webhookUrl: text('webhook_url'),
+    webhookSecret: text('webhook_secret'),
   },
   (t) => [
     index('form_user_idx').on(t.userId),

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -8,3 +8,4 @@ export * from './relations';
 export * from './sessions';
 export * from './users';
 export * from './verification';
+export * from './webhook-delivery-logs';

--- a/packages/db/schema/relations.ts
+++ b/packages/db/schema/relations.ts
@@ -7,6 +7,7 @@ import { formDatas } from './form-data';
 import { forms } from './forms';
 import { sessions } from './sessions';
 import { users } from './users';
+import { webhookDeliveryLogs } from './webhook-delivery-logs';
 
 export const userRelations = relations(users, ({ many }) => ({
   forms: many(forms),
@@ -36,6 +37,7 @@ export const formRelations = relations(forms, ({ one, many }) => ({
     references: [users.id],
   }),
   formData: many(formDatas),
+  webhookDeliveryLogs: many(webhookDeliveryLogs),
 }));
 
 export const formDataRelations = relations(formDatas, ({ one }) => ({
@@ -44,3 +46,17 @@ export const formDataRelations = relations(formDatas, ({ one }) => ({
     references: [forms.id],
   }),
 }));
+
+export const webhookDeliveryLogRelations = relations(
+  webhookDeliveryLogs,
+  ({ one }) => ({
+    form: one(forms, {
+      fields: [webhookDeliveryLogs.formId],
+      references: [forms.id],
+    }),
+    formData: one(formDatas, {
+      fields: [webhookDeliveryLogs.formDataId],
+      references: [formDatas.id],
+    }),
+  }),
+);

--- a/packages/db/schema/webhook-delivery-logs.ts
+++ b/packages/db/schema/webhook-delivery-logs.ts
@@ -1,0 +1,39 @@
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import { formDatas } from './form-data';
+import { forms } from './forms';
+
+export const webhookDeliveryLogs = sqliteTable(
+  'webhook_delivery_logs',
+  {
+    id: text('id').primaryKey(),
+    formId: text('form_id')
+      .references(() => forms.id, { onDelete: 'cascade' })
+      .notNull(),
+    formDataId: text('form_data_id').references(() => formDatas.id, {
+      onDelete: 'set null',
+    }),
+    webhookUrl: text('webhook_url').notNull(),
+    payload: text('payload').notNull(),
+    status: text('status', { enum: ['pending', 'success', 'failed'] })
+      .default('pending')
+      .notNull(),
+    statusCode: integer('status_code'),
+    responseBody: text('response_body'),
+    errorMessage: text('error_message'),
+    attempts: integer('attempts').default(0).notNull(),
+    nextRetryAt: integer('next_retry_at', { mode: 'timestamp_ms' }),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    completedAt: integer('completed_at', { mode: 'timestamp_ms' }),
+  },
+  (t) => [
+    index('webhook_log_form_idx').on(t.formId),
+    index('webhook_log_status_idx').on(t.status),
+    index('webhook_log_next_retry_idx').on(t.nextRetryAt),
+  ],
+);
+
+export type WebhookDeliveryLog = typeof webhookDeliveryLogs.$inferSelect;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,8 @@
     "./server": "./server.ts",
     "./flatten-object": "./flatten-object.ts",
     "./generate-id": "./generate-id.ts",
-    "./url": "./url.ts"
+    "./url": "./url.ts",
+    "./webhook": "./webhook.ts"
   },
   "scripts": {
     "lint": "eslint . --cache --max-warnings 0",

--- a/packages/utils/webhook.ts
+++ b/packages/utils/webhook.ts
@@ -19,24 +19,40 @@ export function isValidWebhookUrl(url: string): boolean {
 
   if (parsed.protocol !== 'https:') return false;
 
+  const isIpv6Literal = hostname.startsWith('[') && hostname.endsWith(']');
+  const host = isIpv6Literal ? hostname.slice(1, -1) : hostname;
+
+  if (isIpv6Literal) {
+    if (
+      host === '::1' ||
+      host.startsWith('fc') ||
+      host.startsWith('fd') ||
+      host.startsWith('fe8') ||
+      host.startsWith('fe9') ||
+      host.startsWith('fea') ||
+      host.startsWith('feb')
+    ) {
+      return false;
+    }
+  }
+
   if (
-    hostname === 'localhost' ||
-    hostname === '127.0.0.1' ||
-    hostname === '::1' ||
-    hostname.endsWith('.local')
+    host === 'localhost' ||
+    host === '0.0.0.0' ||
+    host.endsWith('.local') ||
+    host.startsWith('127.') ||
+    host.startsWith('10.') ||
+    host.startsWith('192.168.') ||
+    host.startsWith('169.254.')
   ) {
     return false;
   }
 
-  if (
-    hostname.startsWith('10.') ||
-    hostname.startsWith('192.168.') ||
-    hostname.startsWith('169.254.')
-  ) {
+  if (/^\d+$/.test(host) || /^0x[0-9a-f]+$/i.test(host)) {
     return false;
   }
 
-  const match172 = /^172\.(\d{1,3})\./.exec(hostname);
+  const match172 = /^172\.(\d{1,3})\./.exec(host);
   if (match172) {
     const secondOctet = Number(match172[1]);
     if (secondOctet >= 16 && secondOctet <= 31) return false;

--- a/packages/utils/webhook.ts
+++ b/packages/utils/webhook.ts
@@ -1,0 +1,46 @@
+export function isValidWebhookUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  const isProduction = process.env['NODE_ENV'] === 'production';
+
+  if (!isProduction) {
+    if (parsed.protocol === 'https:') return true;
+    if (parsed.protocol === 'http:') {
+      return hostname === 'localhost' || hostname === '127.0.0.1';
+    }
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:') return false;
+
+  if (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname.endsWith('.local')
+  ) {
+    return false;
+  }
+
+  if (
+    hostname.startsWith('10.') ||
+    hostname.startsWith('192.168.') ||
+    hostname.startsWith('169.254.')
+  ) {
+    return false;
+  }
+
+  const match172 = /^172\.(\d{1,3})\./.exec(hostname);
+  if (match172) {
+    const secondOctet = Number(match172[1]);
+    if (secondOctet >= 16 && secondOctet <= 31) return false;
+  }
+
+  return true;
+}

--- a/tests/api/form.test.ts
+++ b/tests/api/form.test.ts
@@ -1,11 +1,12 @@
+import type { TestSession, TestUser } from '../helpers';
+
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   createAuthenticatedCaller,
   createTestSession,
   createTestUser,
-  type TestSession,
-  type TestUser,
+  createUnauthenticatedCaller,
 } from '../helpers';
 
 describe('Form API', () => {
@@ -66,6 +67,24 @@ describe('Form API', () => {
       const form = await caller.form.get({ formId: created.id });
       expect(form?.title).toBe('Updated Title');
       expect(form?.description).toBe('New description');
+    });
+  });
+
+  describe('form.getFormById', () => {
+    it('does not expose webhook config through public lookup', async () => {
+      const created = await caller.form.create({ title: 'Webhook Form' });
+      await caller.form.update({
+        id: created.id,
+        enableWebhook: true,
+        webhookUrl: 'https://example.com/webhook',
+      });
+
+      const publicCaller = await createUnauthenticatedCaller();
+      const form = await publicCaller.form.getFormById({ formId: created.id });
+
+      expect(form).not.toBeNull();
+      expect(form).not.toHaveProperty('enableWebhook');
+      expect(form).not.toHaveProperty('webhookUrl');
     });
   });
 

--- a/tests/api/webhook.test.ts
+++ b/tests/api/webhook.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMockPayload,
+  findStuckDeliveries,
+} from '@formbase/api/lib/webhook';
+import { webhookDeliveryLogs } from '@formbase/db/schema';
+import { generateId } from '@formbase/utils/generate-id';
+
+import { createTestForm, createTestUser, getTestDb } from '../helpers';
+
+describe('Webhook helpers', () => {
+  it('leases at most the requested stuck deliveries', async () => {
+    const db = getTestDb();
+    const user = await createTestUser({
+      email: 'webhook-helper@example.com',
+      password: 'Password123!',
+    });
+    const form = await createTestForm({
+      userId: user.id,
+      title: 'Webhook Form',
+    });
+    const payload = JSON.stringify(buildMockPayload(form));
+    const createdAt = new Date(Date.now() - 10000);
+
+    await db.insert(webhookDeliveryLogs).values(
+      Array.from({ length: 101 }, () => ({
+        id: generateId(15),
+        formId: form.id,
+        webhookUrl: 'https://example.com/webhook',
+        payload,
+        status: 'pending' as const,
+        attempts: 0,
+        createdAt,
+      })),
+    );
+
+    const leased = await findStuckDeliveries(db, {
+      olderThanMs: 1000,
+      leaseMs: 60000,
+      limit: 100,
+    });
+
+    const rows = await db.query.webhookDeliveryLogs.findMany({
+      columns: { nextRetryAt: true },
+    });
+
+    expect(leased).toHaveLength(100);
+    expect(rows.filter((row) => row.nextRetryAt !== null)).toHaveLength(100);
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,5 +1,8 @@
-import { createClient, type Client } from '@libsql/client';
-import { drizzle, type LibSQLDatabase } from 'drizzle-orm/libsql';
+import type { Client } from '@libsql/client';
+import type { LibSQLDatabase } from 'drizzle-orm/libsql';
+
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
 
 import * as schema from '@formbase/db/schema';
 
@@ -60,6 +63,9 @@ CREATE TABLE IF NOT EXISTS forms (
   enable_retention INTEGER DEFAULT 1 NOT NULL,
   default_submission_email TEXT,
   honeypot_field TEXT DEFAULT '_gotcha' NOT NULL,
+  enable_webhook INTEGER DEFAULT false NOT NULL,
+  webhook_url TEXT,
+  webhook_secret TEXT,
   FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 );
 
@@ -72,6 +78,24 @@ CREATE TABLE IF NOT EXISTS form_datas (
   spam_reason TEXT,
   manual_override INTEGER DEFAULT 0 NOT NULL,
   FOREIGN KEY (form_id) REFERENCES forms(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS webhook_delivery_logs (
+  id TEXT PRIMARY KEY NOT NULL,
+  form_id TEXT NOT NULL,
+  form_data_id TEXT,
+  webhook_url TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  status TEXT DEFAULT 'pending' NOT NULL,
+  status_code INTEGER,
+  response_body TEXT,
+  error_message TEXT,
+  attempts INTEGER DEFAULT 0 NOT NULL,
+  next_retry_at INTEGER,
+  created_at INTEGER DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+  completed_at INTEGER,
+  FOREIGN KEY (form_id) REFERENCES forms(id) ON DELETE CASCADE,
+  FOREIGN KEY (form_data_id) REFERENCES form_datas(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS onboarding_forms (
@@ -111,6 +135,9 @@ CREATE INDEX IF NOT EXISTS form_user_idx ON forms(user_id);
 CREATE INDEX IF NOT EXISTS form_created_at_idx ON forms(created_at);
 CREATE INDEX IF NOT EXISTS form_idx ON form_datas(form_id);
 CREATE INDEX IF NOT EXISTS form_data_created_at_idx ON form_datas(created_at);
+CREATE INDEX IF NOT EXISTS webhook_log_form_idx ON webhook_delivery_logs(form_id);
+CREATE INDEX IF NOT EXISTS webhook_log_status_idx ON webhook_delivery_logs(status);
+CREATE INDEX IF NOT EXISTS webhook_log_next_retry_idx ON webhook_delivery_logs(next_retry_at);
 CREATE INDEX IF NOT EXISTS verification_identifier_idx ON verification(identifier);
 CREATE INDEX IF NOT EXISTS api_key_user_idx ON api_keys(user_id);
 CREATE INDEX IF NOT EXISTS api_key_hash_idx ON api_keys(key_hash);
@@ -118,6 +145,7 @@ CREATE INDEX IF NOT EXISTS api_key_hash_idx ON api_keys(key_hash);
 
 const RESET_SQL = `
 DELETE FROM api_keys;
+DELETE FROM webhook_delivery_logs;
 DELETE FROM form_datas;
 DELETE FROM onboarding_forms;
 DELETE FROM forms;


### PR DESCRIPTION
## Summary

Adds form **webhooks** — when a submission arrives, formbase POSTs it to a user-configured URL with retries — built entirely on **Cloudflare-native primitives**. This replaces the approach in #121 (BullMQ + Redis + a separately deployed Fly.io worker), which required an always-on external service.

- **Cloudflare Queues** handle delivery, retry/backoff, and a dead-letter queue.
- **Cloudflare Cron Triggers** run a safety-net sweep (re-drives stuck deliveries) and daily log cleanup.
- No Redis, no BullMQ, no separate service.

## How it works

```
POST /api/s/[id] / form.testWebhook
  → insert webhook_delivery_logs row (pending)
  → after() → WEBHOOK_QUEUE.send({ deliveryLogId, webhookUrl })   (deferred, never a floating promise)
        → worker.ts queue(): deliver via fetch + HMAC sign → mark success / retry w/ backoff
        → exhausted → DLQ → mark failed
  worker.ts scheduled(): */5 sweep stuck rows · 0 3 cleanup logs >90d
```

The custom OpenNext worker entry (`apps/web/worker.ts`) re-exports the generated `fetch` handler + cache DOs and adds `queue()`/`scheduled()`. It hydrates `process.env` from the bindings **before** dynamically importing the consumer/scheduled modules, so the workerd handlers can reach the validated env (which `next dev`'s request context normally provides).

## What's better than #121

- **HMAC signing** (was unsigned): WebCrypto HMAC-SHA256 over `timestamp.body`, sent as `X-Formbase-Signature` / `X-Formbase-Event` / `X-Formbase-Timestamp`, with a per-form `webhook_secret`.
- **No floating promise**: enqueue is deferred with `after()` (the pattern that caused the submission hang fixed in #141), not `void promise`.
- **SSRF-hardened** URL validation: production requires public HTTPS and rejects localhost/private ranges.
- **Delivery visibility**: a read-only "Recent deliveries" list + signing-secret field in form settings (the `webhook_delivery_logs` table in #121 was never surfaced).
- **Idempotency**: at-least-once delivery with skip-on-success; submission `id` is a stable idempotency key for receivers.
- The signing secret is **never** exposed through the public `getFormById` procedure (explicit column allowlist).
- The cron sweep **atomically leases** stuck rows (`UPDATE … SET next_retry_at … RETURNING`) so it can't double-deliver rows still in the queue's own retry window.

## Changes

- **schema**: `webhook_delivery_logs` table; `forms.enable_webhook` / `webhook_url` / `webhook_secret`; migration `0003_awesome_inhumans`.
- **packages/api/lib/webhook.ts**: pure, runtime-agnostic payload/log/query helpers.
- **apps/web/src/lib/webhooks/**: `producer`, `deliver` (HMAC), `consumer` (backoff + DLQ), `scheduled` (sweep + cleanup).
- **tRPC**: `form.update` webhook fields + server-generated secret, `form.testWebhook`, `form.listDeliveries`; `setFormData` now returns `{ id }`; queue threaded through context.
- **config**: `wrangler.jsonc` queues/DLQ/cron + `main` → `./worker.ts`; `cloudflare-env.d.ts` gitignored; `tsconfig` `checkJs:false`.
- Deleted the stale `apps/worker/` and `packages/queue/` leftovers from #121.

## Verification

- `@formbase/db`, `@formbase/utils`, `@formbase/api`: typecheck clean.
- apps/web: no typecheck/lint errors in any webhook file.
- Reviewed by an adversarial multi-lens pass (workerd runtime, queue/retry/idempotency, HMAC, type boundaries, migration, SSRF).

## Before deploying

1. Create the queues: `wrangler queues create formbase-webhooks` and `wrangler queues create formbase-webhooks-dlq`.
2. Apply the migration (`packages/db` → `db:migrate`).
3. Queue/cron handlers only run under `wrangler dev` / `opennextjs-cloudflare preview` (not `next dev`); validate end-to-end against a `webhook.site` URL.

## Known follow-ups (low severity)

- DLQ `markFailed` could be wrapped in `try/finally` before `ack()`.
- `isValidWebhookUrl` denylist has IPv6/numeric-host gaps (backstopped by `global_fetch_strictly_public`).
- Test button reads the saved URL prop rather than the live field value.